### PR TITLE
Refactor get_city_country function to remove optional comma parameter and update docstring; enhance test for correct formatting

### DIFF
--- a/chapter-11_testing_your_code/11-1_city_country/module_city_functions.py
+++ b/chapter-11_testing_your_code/11-1_city_country/module_city_functions.py
@@ -1,12 +1,12 @@
-def get_city_country(city, country, comma=","):
+def get_city_country(city, country):
     """
-    Generate a formatted string of a city and country.
+    Generate a formatted string of the form 'City, Country'.
     Args:
         city (str): The name of the city.
         country (str): The name of the country.
-        comma (str, optional): The separator between city and country. Defaults to ",".
     Returns:
-        str: A formatted string in the form 'City, Country'.
+        str: A string formatted as 'City, Country' with title case.
     """
-    city_country = f"{city}{comma} {country}"
+
+    city_country = f"{city}, {country}"
     return city_country.title()

--- a/chapter-11_testing_your_code/11-1_city_country/test_cities.py
+++ b/chapter-11_testing_your_code/11-1_city_country/test_cities.py
@@ -2,5 +2,13 @@ from module_city_functions import get_city_country
 
 
 def test_city_country():
+    """
+    Test the get_city_country function to ensure it correctly formats
+    city and country names.
+    This test checks if the function get_city_country, when given the
+    city "São Paulo" and the country "Brasil", returns the formatted
+    string "São Paulo, Brasil".
+    """
+
     formatted_city_country_name = get_city_country("São Paulo", "Brasil")
     assert formatted_city_country_name == "São Paulo, Brasil"


### PR DESCRIPTION
This pull request includes changes to the `chapter-11_testing_your_code` module to simplify the `get_city_country` function and improve the corresponding test documentation. The most important changes are:

Function simplification:

* [`chapter-11_testing_your_code/11-1_city_country/module_city_functions.py`](diffhunk://#diff-4b4c25c2c84dcf9f5eb0bb352e5de6fe758db743710e6a994474529cda20a88aL1-R11): Removed the optional `comma` parameter from the `get_city_country` function and updated the function to always use a comma as the separator between the city and country.

Test documentation improvement:

* [`chapter-11_testing_your_code/11-1_city_country/test_cities.py`](diffhunk://#diff-a4dd9d9f1793574ffae0b4b6b94ae1118f5adb8671f9f31f3e4073ca1291ff91R5-R12): Added a docstring to the `test_city_country` function to describe the purpose of the test and the specific case it checks.